### PR TITLE
Remove mention of adding LS as reviewer.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,5 @@
 
 ## A reference to a related issue in your repository (if applicable)
 
-## @mentions of the person or team responsible for reviewing proposed changes (At least 2 people)
-- 
-
 ## Checklist
 - [ ] I can confirm that my changes are working as intended

--- a/02_assignments/git_assignment.md
+++ b/02_assignments/git_assignment.md
@@ -34,8 +34,8 @@ In this assignment, you will be learning more about `git` and `GitHub` by workin
 Feel free to at any point (recommended after answering every 2 questions) to stage, commit and push your work to GitHub. It is a great way to practice using `git`!
 
 1. When you are done, please stage, commit your changes, and push it to GitHub.
-2. Open up a pull request and add the Learning Support staff as a reviewer. You may need to add them to your repository.
-3. Write down on your pull request what you learned from this assignment. ([Guidelines for Pull Request Descriptions](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md#guidelines-for-pull-request-descriptions))
+2. Open up a pull request.
+3. Write down in your pull request what you learned from this assignment. ([Guidelines for Pull Request Descriptions](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md#guidelines-for-pull-request-descriptions))
 
 ## Criteria
 


### PR DESCRIPTION
- adding LS as reviewer results in notification overload for the teaching team
- teaching team needs to manually accept collaborator invites for every single repo for this to work, it is therefore impractical.