### PR TITLE
GH Actions, Git Cheatsheet, Naming

### DIFF
--- a/.github/workflows/automatic_pr_comment.yaml
+++ b/.github/workflows/automatic_pr_comment.yaml
@@ -1,23 +1,45 @@
-name: Automatic PR Comment
+name: UofT-DSI Main Repository PR Workflow
 
 on:
   pull_request_target:
     types: [opened, synchronize]
 
 jobs:
-  comment:
+  handle-pr:
+    if: github.repository_owner == 'UofT-DSI'
     runs-on: ubuntu-latest
     steps:
-      - name: Comment on PR
+      - name: Handle PR based on source branch
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_number = context.payload.pull_request.number;
+            const pr = context.payload.pull_request;
+            const branchName = pr.head.ref;
+            const issue_number = pr.number;
             const repo = context.repo;
-            const commentBody = `Hello, thank you for your contribution. If you are a participant, please close this pull request and open it in your own forked repository instead of here. Please read the instructions on your onboarding [Assignment Submission Guide](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md) more carefully. If you are not a participant, please give us up to 72 hours to review your PR. Alternatively, you can reach out to us directly to expedite the review process.`;
-            // Check if the PR is made to a repo in the UofT-DSI organization
-            if (repo.owner === 'UofT-DSI') {
-              github.rest.issues.createComment({
+
+            if (branchName.startsWith('assignment')) {
+              const commentBody = `This pull request was made to the wrong repository. Please open it in your own fork instead. Refer to the [Assignment Submission Guide](https://github.com/UofT-DSI/onboarding/blob/main/onboarding_documents/submissions.md) for detailed instructions.`;
+
+              // Comment on the PR
+              await github.rest.issues.createComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                issue_number: issue_number,
+                body: commentBody
+              });
+
+              // Close the PR
+              await github.rest.pulls.update({
+                owner: repo.owner,
+                repo: repo.repo,
+                pull_number: issue_number,
+                state: "closed"
+              });
+            } else {
+              const commentBody = `Thanks for your contribution! 🎉\n\nPlease remember to tag or request a review from the DSI team. Give us up to 72 hours to review your pull request. We appreciate your patience and efforts.`;
+
+              await github.rest.issues.createComment({
                 owner: repo.owner,
                 repo: repo.repo,
                 issue_number: issue_number,

--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: './03_instructional_team/githubpages'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/02_activities/practice/git_advanced.md
+++ b/02_activities/practice/git_advanced.md
@@ -1,6 +1,4 @@
-# Git Advanced Homework
-
-**Note**: Homework problems are not assessed and are provided for your own personal practice. Feel free to discuss these with your peers and learning support during work sessions!
+# Git Advanced Practice Problems
 
 ## Tasks
 The `dtxe/DSI_git_assignment` repository contains a short Python script that 

--- a/02_activities/practice/git_moderate.md
+++ b/02_activities/practice/git_moderate.md
@@ -1,6 +1,4 @@
-# Git Basics
-
-**Note**: Homework problems are not assessed and are provided for your own personal practice. Feel free to discuss these with your peers and learning support during work sessions!
+# Git Moderate Practice Problems
 
 ## Tasks
 ### Task 1

--- a/04_this_cohort/additional_resources/git_cheatsheet.md
+++ b/04_this_cohort/additional_resources/git_cheatsheet.md
@@ -1,0 +1,175 @@
+# 🧠 Git Commands Cheatsheet (with Inline Comments)
+
+## 🔧 Configuration
+
+```bash
+git --help                                      # Show overview of Git commands
+git config --global user.name "Simeon"          # Set your Git username globally
+git config --global user.email "me@simeon.dev"  # Set your Git email globally
+git config list --global                        # List global Git configuration settings
+git config --global core.editor "code --wait"   # Set VS Code as default Git editor
+```
+
+---
+
+## 🔑 Credential Manager
+
+```bash
+git credential-manager github list        # List GitHub credentials currently used
+git credential-manager github login       # Authenticate and store GitHub credentials
+```
+
+---
+
+## 📁 Repositories
+
+```bash
+git init                                  # Initialize a new Git repository in the current folder
+git init -b main                          # Initialize with 'main' as the default branch
+
+git clone <repository_url>               # Clone an existing repository
+git clone <repository_url> <new_dir>     # Clone and rename the directory
+```
+
+---
+
+## 📝 Tracking Files
+
+```bash
+git status                                # Show current changes and staging info
+touch README.md                           # Create a new file named README.md
+git add <file_name>                       # Stage a specific file
+git add -A                                # Stage all modified and new files
+```
+
+---
+
+## ✅ Committing
+
+```bash
+git commit -m "Your message"              # Commit staged changes with a short message
+git commit                                # Open editor to write a full commit message
+```
+
+---
+
+## 🌐 Remotes
+
+```bash
+git remote -v                             # View remote repository URLs
+git remote add origin <url>               # Add a remote named 'origin'
+git remote show origin                    # Show detailed info about 'origin'
+git remote add upstream <url>             # Add a remote for upstream (main project repo)
+git remote rm origin                      # Remove a remote called 'origin'
+```
+
+---
+
+## 🔁 Syncing Changes
+
+```bash
+git fetch origin                          # Download latest changes from 'origin' (no merge)
+git pull origin <branch>                  # Fetch + merge updates from a remote branch
+git pull --rebase origin <branch>         # Fetch + merge with rebase to handle conflicts
+git pull upstream main                    # Pull latest changes from upstream main branch
+git push origin <branch>                  # Push your local branch to 'origin'
+git push -u origin main                   # Push and set upstream tracking for main
+```
+
+---
+
+## 🌿 Branching
+
+`git branch` performs branch admin tasks (eg. list, delete)  
+`git switch` switches your current working directory to different branches
+
+Git provides multiple ways to perform similar actions, and your choice of command strategy will end up being a mix of personal preference and standard practices in your team.
+
+```bash
+git branch -v                             # List all local branches with last commit
+git branch -a                             # List all branches (local + remote)
+git branch <branch_name>                  # Create a new branch from the current commit
+git branch -d <branch_name>               # Delete a local branch
+
+git switch <branch_name>                  # Switch to an existing branch
+git switch -c <branch_name>               # Create a new branch from the current commit and switch to it
+git switch -c <branch_name> <commit_id>   # Create a new branch from a specified commit and switch to it
+```
+
+---
+
+## 🔄 Merging & Conflicts
+
+```bash
+git merge <branch_name>                   # Merge specified branch into current one
+# If conflicts occur:
+# <<<<<<<, =======, >>>>>>> markers will show in affected files
+# Manually edit and fix conflicts, then:
+git add <file_name>                       # Stage the resolved file
+git commit                                # Commit the merge resolution
+```
+
+---
+
+## 🚀 Branching Workflow
+
+```bash
+git switch -c feature-branch              # Create and switch to a new branch
+# Make code changes
+git add -A                                # Stage all new and modified files
+git commit -m "Feature updates"           # Commit with a clear message
+git push origin feature-branch            # Push new branch to remote
+```
+
+---
+
+## 📤 Uploading Changes to GitHub
+
+**Initial Setup:**
+```bash
+# Fork the repo on GitHub
+git clone <repo_url>                      # Clone forked repo to local
+```
+
+**Making Changes:**
+```bash
+git switch -c <new_branch>                # Create and switch to a feature branch
+# Edit files
+git status                                # Check what's modified
+git add -A                                # Stage all changes
+git commit                                # Commit changes
+git push origin <branch>                  # Push feature branch to GitHub
+```
+
+---
+
+## ❌ Undoing Mistakes
+
+### 🔄 Accidental PR Merge
+
+> On GitHub:
+1. Click **"Revert"** on the merged PR  
+2. Merge the auto-created `revert-1-<branch>` PR  
+3. Click "Revert" again on the revert-PR  
+4. Leave the final "revert of a revert" PR open as the actual submission
+
+
+### ⛔ Undoing an accidental push to GitHub
+
+**⚠️ The commands shown here should be used with caution.**
+
+#### Important caveats
+* Generally, anything uploaded to the internet should be considered to have been made public permanently.
+  * If you accidentally uploaded a password or other credentials, those should be revoked immediately.
+* It is considered bad practice to change Git history. These commands should only be used in very specific circumstances.
+
+#### Steps
+* Optionally, backup your current latest commit that was accidentally pushed
+    * `git switch -c backup-branch`
+* Ensure your local branch is at the correct commit that should be uploaded
+    * Use `git log` to find the commit ID you want to revert a branch to
+* Revert your local branch to the correct commit
+    * `git switch -C [branch name] [commit id]` to overwrite the branch, and set it to the specified commit ID
+* Overwrite the GitHub repository with the updated branch
+    * `git push origin [branch name] –-force`
+

--- a/04_this_cohort/additional_resources/git_cheatsheet.md
+++ b/04_this_cohort/additional_resources/git_cheatsheet.md
@@ -70,7 +70,7 @@ git remote rm origin                      # Remove a remote called 'origin'
 ```bash
 git fetch origin                          # Download latest changes from 'origin' (no merge)
 git pull origin <branch>                  # Fetch + merge updates from a remote branch
-git pull --rebase origin <branch>         # Fetch + merge with rebase to handle conflicts
+git pull --no-rebase origin <branch>      # Fetch + merge without rebasing to preserve the commit history
 git pull upstream main                    # Pull latest changes from upstream main branch
 git push origin <branch>                  # Push your local branch to 'origin'
 git push -u origin main                   # Push and set upstream tracking for main

--- a/04_this_cohort/additional_resources/git_cheatsheet.md
+++ b/04_this_cohort/additional_resources/git_cheatsheet.md
@@ -171,5 +171,4 @@ git push origin <branch>                  # Push feature branch to GitHub
 * Revert your local branch to the correct commit
     * `git switch -C [branch name] [commit id]` to overwrite the branch, and set it to the specified commit ID
 * Overwrite the GitHub repository with the updated branch
-    * `git push origin [branch name] –-force`
-
+    * `git push origin [branch name] --force`

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Assignments are typically due on the Sunday following the module's live learning
 **Questions can be submitted to the _#dc-help_ channel on Slack**
 
 * Technical Facilitator:   
-  * **Simeon Wong**
+  * **Simeon Wong**  
     me@simeon.dev
 
 * Learning Support Staff: 
-  * **Dmytro Bonislavskyi**
+  * **Dmytro Bonislavskyi**  
   dmytro.bonislavskyi@gmail.com
-  * **Laura MacKew**
+  * **Laura MacKew**  
   lauramackew@gmail.com
-  * **Moniz Chan**
+  * **Moniz Chan**  
   moniz.chan@utoronto.ca
 
  


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows, adding the Git Cheatsheet, and misc naming changes.

### GitHub Workflows:
* automatically close PRs made to `UofT-DSI/git/main` if they come from a branch named `assignment`
   * Although the Git repo shouldn't receive any assignment PRs anymore, this file is updated to sync with the corresponding update in the shell repo

### Documentation Updates:

* [`02_activities/practice/git_advanced.md`](diffhunk://#diff-2f54752a1b0d5a413c7b6e77dd25013685d1a25f592058110964babfc25ea28cL1-R1): Updated the title from "Git Advanced Homework" to "Git Advanced Practice Problems"

* [`02_activities/practice/git_moderate.md`](diffhunk://#diff-b2d6bb971e47ae197e77b8032d3d22ee7f61cf203ee48529c0cf6976ed07f945L1-R1): Fixed title mismatch, from "Git Basics" to "Git Moderate Practice Problems"

* [`04_this_cohort/additional_resources/git_cheatsheet.md`](diffhunk://#diff-367c32392ba46fd24536ca0f4ae4655fc1139e149f6bff8c8d199c7fa5804a12R1-R175): Added a comprehensive Git commands cheatsheet based on previous cohort scratchpads intended to supplement the live scratchpad notes